### PR TITLE
feat: 添加 Azul Zulu JDK 25 支持

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM azul/zulu-openjdk:11-latest as java11
 FROM azul/zulu-openjdk:17-latest as java17
 FROM azul/zulu-openjdk:21-latest as java21
 FROM azul/zulu-openjdk:24-latest as java24
+FROM azul/zulu-openjdk:25-latest as java25
 
 # 最终镜像
 FROM debian:12-slim
@@ -19,10 +20,11 @@ COPY --from=java11 /usr/lib/jvm/zulu11 /usr/lib/jvm/zulujdk-11
 COPY --from=java17 /usr/lib/jvm/zulu17 /usr/lib/jvm/zulujdk-17
 COPY --from=java21 /usr/lib/jvm/zulu21 /usr/lib/jvm/zulujdk-21
 COPY --from=java24 /usr/lib/jvm/zulu24 /usr/lib/jvm/zulujdk-24
+COPY --from=java25 /usr/lib/jvm/zulu25 /usr/lib/jvm/zulujdk-25
 
 # 验证复制的JDK
 RUN echo "🔍 验证从官方镜像复制的JDK..." && \
-    for v in 8 11 17 21 24; do \
+    for v in 8 11 17 21 24 25; do \
         if [ -d "/usr/lib/jvm/zulujdk-$v" ]; then \
             echo "检验 Java $v..." && \
             /usr/lib/jvm/zulujdk-$v/bin/java -version 2>&1 | head -1 && \
@@ -43,12 +45,14 @@ RUN update-alternatives --install /usr/bin/java java /usr/lib/jvm/zulujdk-8/bin/
     update-alternatives --install /usr/bin/javac javac /usr/lib/jvm/zulujdk-21/bin/javac 210 && \
     update-alternatives --install /usr/bin/java java /usr/lib/jvm/zulujdk-24/bin/java 240 && \
     update-alternatives --install /usr/bin/javac javac /usr/lib/jvm/zulujdk-24/bin/javac 240 && \
+    update-alternatives --install /usr/bin/java java /usr/lib/jvm/zulujdk-25/bin/java 250 && \
+    update-alternatives --install /usr/bin/javac javac /usr/lib/jvm/zulujdk-25/bin/javac 250 && \
     update-alternatives --set java /usr/lib/jvm/zulujdk-17/bin/java && \
     update-alternatives --set javac /usr/lib/jvm/zulujdk-17/bin/javac
 
 # 创建Java版本切换脚本
 RUN echo '#!/bin/bash' > /usr/bin/java-change && \
-    echo 'if [ -z "$1" ]; then echo "用法: java-change {8|11|17|21|24}"; echo "当前Java版本:"; java -version; exit 1; fi' >> /usr/bin/java-change && \
+    echo 'if [ -z "$1" ]; then echo "用法: java-change {8|11|17|21|24|25}"; echo "当前Java版本:"; java -version; exit 1; fi' >> /usr/bin/java-change && \
     echo 'if [ ! -d "/usr/lib/jvm/zulujdk-$1" ]; then echo "❌ Java $1 未安装"; exit 1; fi' >> /usr/bin/java-change && \
     echo 'update-alternatives --set java /usr/lib/jvm/zulujdk-$1/bin/java && update-alternatives --set javac /usr/lib/jvm/zulujdk-$1/bin/javac' >> /usr/bin/java-change && \
     echo 'echo "✅ Java 已切换至版本 $1"' >> /usr/bin/java-change && \
@@ -56,7 +60,7 @@ RUN echo '#!/bin/bash' > /usr/bin/java-change && \
     chmod +x /usr/bin/java-change
 
 # 创建各版本直接命令
-RUN for v in 8 11 17 21 24; do \
+RUN for v in 8 11 17 21 24 25; do \
         if [ -d "/usr/lib/jvm/zulujdk-$v" ]; then \
             printf '#!/bin/bash\nexec /usr/lib/jvm/zulujdk-%s/bin/java "$@"\n' "$v" > /usr/bin/java"$v"; \
             chmod +x /usr/bin/java"$v"; \
@@ -66,7 +70,7 @@ RUN for v in 8 11 17 21 24; do \
 # 创建版本列表脚本
 RUN echo '#!/bin/bash' > /usr/bin/java-list && \
     echo 'echo "📦 可用Java版本:"' >> /usr/bin/java-list && \
-    echo 'for v in 8 11 17 21 24; do' >> /usr/bin/java-list && \
+    echo 'for v in 8 11 17 21 24 25; do' >> /usr/bin/java-list && \
     echo '  if [ -d "/usr/lib/jvm/zulujdk-$v" ]; then' >> /usr/bin/java-list && \
     echo '    version_info=$(/usr/lib/jvm/zulujdk-$v/bin/java -version 2>&1 | head -1 | cut -d"\"" -f2)' >> /usr/bin/java-list && \
     echo '    current_java=$(readlink -f /usr/bin/java)' >> /usr/bin/java-list && \

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 包含多版本Java的Docker镜像，开箱即用。
 
 ## 📦 版本
-Java 8, 11, 17, 21, 24 (Azul Zulu JDK)，默认Java 17
+Java 8, 11, 17, 21, 24, 25 (Azul Zulu JDK)，默认Java 17
 
 使用官方 `azul/zulu-openjdk:*-latest` 镜像作为源
 
 ## 🔧 命令
 - `java` - 默认版本
-- `java8`, `java11`, `java17`, `java21`, `java24` - 直接使用特定版本  
+- `java8`, `java11`, `java17`, `java21`, `java24`, `java25` - 直接使用特定版本  
 - `java-change <版本>` - 切换默认版本
 - `java-list` - 显示所有版本
 - `java-current` - 显示当前配置详情

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "multi-java",
   "version": "1.0.0",
-  "description": "多版本Java Docker镜像，支持Java 8/11/17/21/24",
+  "description": "多版本Java Docker镜像，支持Java 8/11/17/21/24/25",
   "repository": {
     "type": "git",
     "url": "https://github.com/WittF/docker-multi-java.git"


### PR DESCRIPTION
## 变更内容
- 新增 Azul Zulu JDK 25 (基于 `azul/zulu-openjdk:25-latest`)
- 更新 Dockerfile、README.md、package.json

## 新增命令
- `java25` - 直接使用 JDK 25
- `java-change 25` - 切换默认版本至 25